### PR TITLE
#65 - Add a ground-constrained RGV cost function to "Orbiting Azimuth Sim"

### DIFF
--- a/Orbiting Azimuth Sim/Cost Functions/cost2D.m
+++ b/Orbiting Azimuth Sim/Cost Functions/cost2D.m
@@ -1,0 +1,15 @@
+function cost = cost2D(vec_rgvPositionEstimate_en, trix_vec_sensorPointingVec_enu, trix_vec_samplePosition_enu)
+    % Given a ground-constrained RGV position estimate (Easting and
+    % Northing), determines how bad of a guess it is by summing the squares
+    % of the distances from the guess to each 3D line created by each
+    % sensor pointing vector and sample position.
+    arguments(Input)
+        vec_rgvPositionEstimate_en (1,2) double      % A guess of where the RGV is, but only the North and East parts
+        trix_vec_sensorPointingVec_enu (:,3) double  % A matrix where each row is a sensor pointing vector
+        trix_vec_samplePosition_enu (:,3) double     % A matrix where each row is a UAS position
+    end
+    arguments(Output)
+        cost (1,1) double                            % How bad the guess was
+    end
+    cost = sum(vecnorm(cross(trix_vec_sensorPointingVec_enu,[vec_rgvPositionEstimate_en,0]-trix_vec_samplePosition_enu,2),2,2).^2);
+end

--- a/Orbiting Azimuth Sim/Cost Functions/cost3D.m
+++ b/Orbiting Azimuth Sim/Cost Functions/cost3D.m
@@ -1,0 +1,14 @@
+function cost = cost3D(vec_rgvPositionEstimate_enu, trix_vec_sensorPointingVec_enu, trix_vec_samplePosition_enu)
+    % Given an RGV position estimate, determines how bad of a guess it is
+    % by summing the squares of the distances from the guess to each 3D
+    % line created by each sensor pointing vector and sample position.
+    arguments(Input)
+        vec_rgvPositionEstimate_enu (1,3) double      % A guess of where the RGV is
+        trix_vec_sensorPointingVec_enu (:,3) double  % A matrix where each row is a sensor pointing vector
+        trix_vec_samplePosition_enu (:,3) double     % A matrix where each row is a UAS position
+    end
+    arguments(Output)
+        cost (1,1) double                            % How bad the guess was
+    end
+    cost = sum(vecnorm(cross(trix_vec_sensorPointingVec_enu,vec_rgvPositionEstimate_enu-trix_vec_samplePosition_enu,2),2,2).^2);
+end

--- a/Orbiting Azimuth Sim/OrbAzMonteParams.m
+++ b/Orbiting Azimuth Sim/OrbAzMonteParams.m
@@ -1,13 +1,13 @@
 classdef OrbAzMonteParams
     % Speficies the range of values for a Monte Carlo sim to test
     properties
-        minOrbitDistance (1,1) double = 1;     % [m] The minimum orbit distance to test
-        maxOrbitDistance (1,1) double = 9;    % [m] The maximum orbit distance to test
-        orbitDistanceGap (1,1) double = 1;   % [m] The size of the gap between each tested orbit distance
+        minOrbitDistance (1,1) double = 0;     % [m] The minimum orbit distance to test
+        maxOrbitDistance (1,1) double = 10;    % [m] The maximum orbit distance to test
+        orbitDistanceGap (1,1) double = 1;     % [m] The size of the gap between each tested orbit distance
         minAngleStdDeg (1,1) double = 1;       % [deg] The minimum pointing angle error (std) to test
         maxAngleStdDeg (1,1) double = 5;       % [deg] The maximum pointing angle error (std) to test
         angleStdGapDeg (1,1) double = 1;       % [deg] The size of the gap between each tested pointing angle error (std)
         sameSeedForAll (1,1) logical = false;  % Whether or not to use the same random seed for each trial
-        trialsPerCase (1,1) double = 200;
+        trialsPerCase (1,1) double = 500;
     end
 end

--- a/Orbiting Azimuth Sim/OrbAzParams.m
+++ b/Orbiting Azimuth Sim/OrbAzParams.m
@@ -9,6 +9,7 @@ classdef OrbAzParams
         angleStdDeg (1,1) double = 3;      % [deg] Standard deviation of sensor pointing angle error
         sampleRate (1,1) double = 1;       % [Hz] How often the sensor measures
         orbitCount (1,1) double = 1;       % How many orbits the UAS should do per duration
+        use2DcostFunction (1,1) logical = true  % Whether to use the 2D cost function to estimate the RGV position. If false, uses 3D cost function
     end
 
     properties(Dependent)
@@ -37,6 +38,9 @@ classdef OrbAzParams
         end
         function val = get.orbitAngularSpeed(this)
             val = this.orbitSpeed / this.orbitDistance;
+            if (isnan(val))
+                val = 1;
+            end
         end
         function this = set.orbitAngularSpeed(this, newVal)
             this.orbitSpeed = newVal * this.orbitDistance;

--- a/Orbiting Azimuth Sim/_Runners/orbitMonteCarlo.m
+++ b/Orbiting Azimuth Sim/_Runners/orbitMonteCarlo.m
@@ -89,9 +89,8 @@ function orbitMonteCarlo(monteParams, params)
     ylabel("Mean Estimate Error [m]")
     title("RGV Position Estimate Mean Error")
     xlim([monteParams.minOrbitDistance monteParams.maxOrbitDistance])
-    ylimlower = min(trix_meanErrorMagnitude, [], "all");
     ylimupper = max(trix_meanErrorMagnitude, [], "all");
-    ylim([ylimlower ylimupper])
+    ylim([0 ylimupper])
     legend(Location="best")
     set(gcf,"Color","#f0d7ad")
     
@@ -106,9 +105,8 @@ function orbitMonteCarlo(monteParams, params)
     ylabel("Bias Magnitude [m]")
     title("RGV Position Estimate Bias Magnitude")
     xlim([monteParams.minOrbitDistance monteParams.maxOrbitDistance])
-    ylimlower = min(trix_biasMagnitude, [], "all");
     ylimupper = max(trix_biasMagnitude, [], "all");
-    ylim([ylimlower ylimupper])
+    ylim([0 ylimupper])
     legend(Location="best")
     set(gcf,"Color","#edf0ad")
     
@@ -146,7 +144,9 @@ function orbitMonteCarlo(monteParams, params)
     xlabel("Orbit Distance [m]")
     ylabel("sigma_z [m]")
     xlim([monteParams.minOrbitDistance monteParams.maxOrbitDistance])
-    ylim([0 max(trix_sigma_z, [], "all")])
+    if (trix_sigma_z ~= 0)
+        ylim([0 max(trix_sigma_z, [], "all")])
+    end
     
     % Plot bias by axis
     figure
@@ -182,5 +182,7 @@ function orbitMonteCarlo(monteParams, params)
     xlabel("Orbit Distance [m]")
     ylabel("Z Bias [m]")
     xlim([monteParams.minOrbitDistance monteParams.maxOrbitDistance])
-    ylim([min(trix3_vec_bias_enu(3,:,:), [], "all") max(trix3_vec_bias_enu(3,:,:), [], "all")])
+    if (trix3_vec_bias_enu(3,:,:) ~= 0)
+        ylim([min(trix3_vec_bias_enu(3,:,:), [], "all") max(trix3_vec_bias_enu(3,:,:), [], "all")])
+    end
 end

--- a/Orbiting Azimuth Sim/getPrediction.m
+++ b/Orbiting Azimuth Sim/getPrediction.m
@@ -10,5 +10,10 @@ function vec_predictedRgvLocation_enu = getPrediction(trix_vec_sensorPointingVec
         vec_predictedRgvLocation_enu (1,3) double
     end
 
-    vec_predictedRgvLocation_enu = fminsearch(@(x) sqrt(sum(vecnorm(cross(trix_vec_sensorPointingVec_enu,x-trix_vec_samplePosition_enu,2),2,2).^2))/params.sampleCount, [0,0,0]);
+    if (params.use2DcostFunction)
+        vec_predictedRgvLocation_en = fminsearch(@(vec_predictedRgvLocation_en) cost2D(vec_predictedRgvLocation_en,trix_vec_sensorPointingVec_enu,trix_vec_samplePosition_enu), [0,0]);
+        vec_predictedRgvLocation_enu = [vec_predictedRgvLocation_en, 0];
+    else
+        vec_predictedRgvLocation_enu = fminsearch(@(vec_predictedRgvLocation_enu) cost3D(vec_predictedRgvLocation_enu,trix_vec_sensorPointingVec_enu,trix_vec_samplePosition_enu), [0,0,0]);
+    end
 end

--- a/Orbiting Azimuth Sim/getSensorPointingVecs.m
+++ b/Orbiting Azimuth Sim/getSensorPointingVecs.m
@@ -16,7 +16,7 @@ function [trix_vec_sensorPointingVec_enu] = getSensorPointingVecs(trix_vec_trueP
     % poining vector. This is stored in a matrix to make the future
     % rotation math easier.
     trix3_vec_specificOrthogonal_enu = zeros(3, 3, params.sampleCount);
-    trix3_vec_specificOrthogonal_enu(:,1,:) = [-trix_vec_truePointingVec_enu(:,2) trix_vec_truePointingVec_enu(:,1) zeros(params.sampleCount,1)]';
+    trix3_vec_specificOrthogonal_enu(:,1,:) = [zeros(params.sampleCount,1) trix_vec_truePointingVec_enu(:,3) -trix_vec_truePointingVec_enu(:,2)]';
     % For each sample, generate a random rotation about the true pointing
     % vector.
     trix3_dcm_specificOrthogonal2randomOrthogonal = axang2rotm([trix_vec_truePointingVec_enu rand(params.sampleCount, 1)*2*pi]);


### PR DESCRIPTION
## Issue

Resolves #65

## Changes

- Pulls the 3D cost function out of `getPrediction.m` and moves it to `cost3D.m`
- Adds a 2D cost function where the Z value is set to 0, called `cost2D.m`
- Adds a property in `OrbAxParams` called `use2DcostFunction` that sets which cost function to use, defaulting to `cost2D`
- Other minor fixes, such as:
    - Fix a divide by zero error that used to occur if the UAS was directly above the RGV
    - Fix the Y limits of some plots

## Results

See #68 to compare. Note that this was still run with the original `OrbAzMonteParams` to make direct comparison easier

![fig1_v2](https://github.com/ARDVARC/ARDVARC/assets/82551807/1586f35d-ea5e-4fe6-a510-ebc3e3b4fd30)
![fig2_v2](https://github.com/ARDVARC/ARDVARC/assets/82551807/825a9e4c-1d26-4b89-ae9a-11c67f1ff274)
![fig3_v2](https://github.com/ARDVARC/ARDVARC/assets/82551807/0c311be8-ea91-42f2-9f07-3a2d673340e2)
![fig4_v2](https://github.com/ARDVARC/ARDVARC/assets/82551807/cb5cca16-b4a0-4e1d-b52a-13a0b2babe3f)
![fig5_v2](https://github.com/ARDVARC/ARDVARC/assets/82551807/522e6c95-74d6-4786-83a8-b9bc2e01a3ea)

2DRMS seems a bit higher which is weird but the Z bias is completely gone so the mean estimate error is way down.

# Future Work
- See #68