### PR TITLE
Add figure formatter for slideshows

### DIFF
--- a/+util/+plotting/slideify.m
+++ b/+util/+plotting/slideify.m
@@ -1,0 +1,29 @@
+function slideify(fignum, bgColor, textColor)
+    % Changes the colors of a figure to match the ARDVARC slideshow theme
+    arguments(Input)
+        fignum (1,1) double
+        bgColor (1,1) string = "#37474f"
+        textColor (1,1) string = "white"
+    end
+    
+    f = figure(fignum);
+    f.Color = bgColor;
+    for i = 1:length(f.Children)
+        g = f.Children(i);
+        if (isa(g, "matlab.graphics.axis.Axes"))
+            % Make axes child match slide color theme
+            g.XColor = textColor;
+            g.YColor = textColor;
+            g.ZColor = textColor;
+            g.Color = bgColor;
+            g.Title.Color = textColor;
+        elseif(isa(g, "matlab.graphics.illustration.Legend"))
+            % Make legend child match slide color theme 
+            g.Color = bgColor;
+            g.TextColor = textColor;
+            g.EdgeColor = textColor;
+        else
+            fprintf("Slideify - Unrecognized child type '%s'\n", class(g))
+        end
+    end
+end


### PR DESCRIPTION
## Changes

- Adds a function under `util.plotting.slideify` which changes the background and font colors of a figure to match the slideshow theme we use. This should make our plots look consistent for slideshows

# Testing

This function was tested on the `Unified MATLAB Mission Simulator` and `Orbiting Azimuth Sim` plots because I'm familiar with them. It seems to correctly handle legends, axis labels, titles, and gridlines for both 2D and 3D plots.

Example:

![3d_normal](https://github.com/ARDVARC/ARDVARC/assets/82551807/284e990a-f255-4ed9-86ac-e7f31b4bd45e)

becomes

![3d_slideify](https://github.com/ARDVARC/ARDVARC/assets/82551807/244ed172-b97b-44c6-be82-03093d70de15)

# Request For Feedback
- I tried the `+` in front of the folder name thing, it seems cool but lmk what you guys think
- This adds a `util` folder to the root of the repo, which seems useful with how we have different simulations organized right now but could be a pain long term. Thoughts?

# Future Work
- This probably breaks for more complicated plots, so if we run into cases where it fails it'll need to be updated
- It doesn't change data colors so blues and blacks are a bit hard to see against the background. It could be updated to look for colors too close to the background and change them to something with higher contrast