### PR TITLE
Switch back to setup functions

### DIFF
--- a/FSW/functional/determine_mission_state.py
+++ b/FSW/functional/determine_mission_state.py
@@ -21,5 +21,15 @@ def _state_machine_criteria_callback(msg: StateMachineCriteria):
     rospy.loginfo("Misison state published")
 
 
-_mission_state_pub = rospy.Publisher(MISSION_STATES, MissionState, queue_size=1)
-_state_machine_criteria_sub = rospy.Subscriber(STATE_MACHINE_CRITERIA, StateMachineCriteria, _state_machine_criteria_callback)
+def setup():
+    """
+    Setup publishers and subscribers for determine_mission_state.py
+    """
+    
+    global _mission_state_pub, _state_machine_criteria_sub
+    _mission_state_pub = rospy.Publisher(MISSION_STATES, MissionState, queue_size=1)
+    _state_machine_criteria_sub = rospy.Subscriber(STATE_MACHINE_CRITERIA, StateMachineCriteria, _state_machine_criteria_callback)
+    
+
+_mission_state_pub: rospy.Publisher
+_state_machine_criteria_sub: rospy.Subscriber

--- a/FSW/functional/estimate_rgv_state.py
+++ b/FSW/functional/estimate_rgv_state.py
@@ -19,9 +19,20 @@ def _direction_vector_callback(msg: UasToRgvDirectionVectorUasFrame):
     rospy.loginfo("RGV state estimator saved direction vector")
 
 
-_estimated_rgv_state_pub = rospy.Publisher(ESTIMATED_RGV_STATES, EstimatedRgvState, queue_size=1)
-_uas_state_sub = rospy.Subscriber(UAS_POSES, PoseStamped, _uas_state_callback)
-_direction_vector_sub = rospy.Subscriber(UAS_TO_RGV_DIRECTION_VECTORS, UasToRgvDirectionVectorUasFrame, _direction_vector_callback)
+def setup():
+    """
+    Setup publishers and subscribers for estimate_rgv_state.py
+    """
+
+    global _estimated_rgv_state_pub, _uas_state_sub, _direction_vector_sub
+    _estimated_rgv_state_pub = rospy.Publisher(ESTIMATED_RGV_STATES, EstimatedRgvState, queue_size=1)
+    _uas_state_sub = rospy.Subscriber(UAS_POSES, PoseStamped, _uas_state_callback)
+    _direction_vector_sub = rospy.Subscriber(UAS_TO_RGV_DIRECTION_VECTORS, UasToRgvDirectionVectorUasFrame, _direction_vector_callback)
+
+
+_estimated_rgv_state_pub: rospy.Publisher
+_uas_state_sub: rospy.Subscriber
+_direction_vector_sub: rospy.Subscriber
 
 
 def estimate_rgv_state():

--- a/FSW/functional/generate_state_machine_criteria.py
+++ b/FSW/functional/generate_state_machine_criteria.py
@@ -33,7 +33,20 @@ def _mission_state_callback(msg: MissionState):
     _mission_state_buffer.appendleft(msg)
 
 
-_state_machine_criteria_pub = rospy.Publisher(STATE_MACHINE_CRITERIA, StateMachineCriteria, queue_size=1)
-_estimated_rgv_state_sub = rospy.Subscriber(ESTIMATED_RGV_STATES, EstimatedRgvState, _estimated_rgv_state_callback)
-_sightings_sub = rospy.Subscriber(RECENT_RGV_SIGHTINGS, RecentSighting, _sightings_callback)
-_mission_state_sub = rospy.Subscriber(MISSION_STATES, MissionState, _mission_state_callback)
+def setup():
+    """
+    Setup publishers and subscribers for generate_state_machine_criteria.py
+    """
+    
+    global _state_machine_criteria_pub, _estimated_rgv_state_sub, _sightings_sub, _mission_state_sub
+    
+    _state_machine_criteria_pub = rospy.Publisher(STATE_MACHINE_CRITERIA, StateMachineCriteria, queue_size=1)
+    _estimated_rgv_state_sub = rospy.Subscriber(ESTIMATED_RGV_STATES, EstimatedRgvState, _estimated_rgv_state_callback)
+    _sightings_sub = rospy.Subscriber(RECENT_RGV_SIGHTINGS, RecentSighting, _sightings_callback)
+    _mission_state_sub = rospy.Subscriber(MISSION_STATES, MissionState, _mission_state_callback)
+
+
+_state_machine_criteria_pub: rospy.Publisher
+_estimated_rgv_state_sub: rospy.Subscriber
+_sightings_sub: rospy.Subscriber
+_mission_state_sub: rospy.Subscriber

--- a/FSW/functional/guidance.py
+++ b/FSW/functional/guidance.py
@@ -56,11 +56,26 @@ def _uas_pose_callback(msg: PoseStamped):
     rospy.loginfo("Guidance saved a UAS pose")
     pass
 
-_setpoint_pub = rospy.Publisher(SETPOINTS, Setpoint, queue_size=1)
-_roi_pub = rospy.Publisher(REGIONS_OF_INTEREST, RegionOfInterest, queue_size=1)
-_estimated_rgv_state_sub = rospy.Subscriber(ESTIMATED_RGV_STATES, EstimatedRgvState, _estimated_rgv_state_callback)
-_mission_state_sub = rospy.Subscriber(MISSION_STATES, MissionState, _mission_state_callback)
-_uas_pose_sub = rospy.Subscriber(UAS_POSES, PoseStamped, _uas_pose_callback)
+
+def setup():
+    """
+    Setup publishers and subscribers for guidance.py
+    """
+    
+    global _setpoint_pub, _roi_pub, _estimated_rgv_state_sub, _mission_state_sub, _uas_pose_sub
+    
+    _setpoint_pub = rospy.Publisher(SETPOINTS, Setpoint, queue_size=1)
+    _roi_pub = rospy.Publisher(REGIONS_OF_INTEREST, RegionOfInterest, queue_size=1)
+    _estimated_rgv_state_sub = rospy.Subscriber(ESTIMATED_RGV_STATES, EstimatedRgvState, _estimated_rgv_state_callback)
+    _mission_state_sub = rospy.Subscriber(MISSION_STATES, MissionState, _mission_state_callback)
+    _uas_pose_sub = rospy.Subscriber(UAS_POSES, PoseStamped, _uas_pose_callback)
+
+
+_setpoint_pub: rospy.Publisher
+_roi_pub: rospy.Publisher
+_estimated_rgv_state_sub: rospy.Subscriber
+_mission_state_sub: rospy.Subscriber
+_uas_pose_sub: rospy.Subscriber
 
 
 def _calc_orbit_setpoint(RGV: EstimatedRgvState, UAS: PoseStamped, t: Time) -> Setpoint:

--- a/FSW/functional/process_bluetooth.py
+++ b/FSW/functional/process_bluetooth.py
@@ -15,5 +15,16 @@ def _bluetooth_callback(msg: BluetoothAzimuthElevation):
     )
 
 
-_direction_vector_pub = rospy.Publisher(UAS_TO_RGV_DIRECTION_VECTORS, UasToRgvDirectionVectorUasFrame, queue_size=1)
-_bluetooth_sub = rospy.Subscriber(RAW_BLUETOOTH, BluetoothAzimuthElevation, _bluetooth_callback)
+def setup():
+    """
+    Setup publishers and subscribers for process_bluetooth.py
+    """
+    
+    global _direction_vector_pub, _bluetooth_sub
+    
+    _direction_vector_pub = rospy.Publisher(UAS_TO_RGV_DIRECTION_VECTORS, UasToRgvDirectionVectorUasFrame, queue_size=1)
+    _bluetooth_sub = rospy.Subscriber(RAW_BLUETOOTH, BluetoothAzimuthElevation, _bluetooth_callback)
+
+
+_direction_vector_pub: rospy.Publisher
+_bluetooth_sub: rospy.Subscriber

--- a/FSW/main.py
+++ b/FSW/main.py
@@ -31,6 +31,13 @@ from rosardvarc.msg import AnnotatedCameraFrame
 # stl imports
 import time
 
+# Call all the setups
+determine_mission_state.setup()
+guidance.setup()
+estimate_rgv_state.setup()
+generate_state_machine_criteria.setup()
+process_bluetooth.setup()
+
 # Run the estimation loop until we die
 rate = rospy.Rate(3)
 now = rospy.Time.now()


### PR DESCRIPTION
## Summary

When I initially built out the callback-based structure on [this branch](https://github.com/ARDVARC/ARDVARC/tree/aidans-fsw-structure), I had each module define a `setup()` function that got called once by the main function that did things like create publishers and subscribers. When I made the [callback structure PR](https://github.com/ARDVARC/ARDVARC/pull/82), however, I got rid of these setup functions in favor of just creating the publishers and subscribers automatically when the module was imported.

While working on the state machine MVP I realized that this made unit tests essentially impossible because if you try to import the module it will automatically try to create publishers and subscribers which you don't want for unit tests.

So this PR goes back to the setup function approach to make unit testing possible.

## Changes

- Go back to the setup function approach

## Concerns

This might cause merge conflicts with stuff people are actively working on which is a pain. I can help resolve them if they show up because this is kind of my fault.
